### PR TITLE
remove dead link

### DIFF
--- a/modules/ROOT/pages/example-testing-apikit.adoc
+++ b/modules/ROOT/pages/example-testing-apikit.adoc
@@ -299,8 +299,7 @@ This example shows how to trigger hits to the endpoint exposed by APIkit, and wh
 
 == Create a Test Suite Automatically
 
-Although this example is meant to showcase how to build a test suite from the ground, MUnit allows you to automatically create a test Suite based on your RAML definitions. +
-This is illustrated in the xref:general:getting-started:implement-and-test.adoc[implementing and testing an API quickstart] section.
+Although this example is meant to showcase how to build a test suite from the ground, MUnit allows you to automatically create a test Suite based on your RAML definitions.
 
 Based on link:{attachmentsdir}/t-shirt.raml[complete t-shirt API definition], the MUnit's scaffolder automatically creates the following test Suite:
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,6 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :version-info: 3.7.0 and newer
 :keywords: munit, testing, unit testing
+:page-aliases: munit:index.adoc
 
 == Overview
 


### PR DESCRIPTION
Related to: https://github.com/mulesoft/docs-general/pull/42

One commit is just to remove a link, the other is the actual page-alias, with correct syntax.

this is one of the PRs needed by https://github.com/mulesoft/docs-general/pull/42 which is removing a file.