### PR TITLE
Fix the assertion in the example

### DIFF
--- a/modules/ROOT/pages/enable-flow-sources-concept.adoc
+++ b/modules/ROOT/pages/enable-flow-sources-concept.adoc
@@ -45,7 +45,9 @@ In order for MUnit to be able to reach that listener, you need to enable the htt
     </munit:execution>
 
     <munit:validation>
-        <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::equalTo('Hello World')]" />
+        <munit-tools:assert-that 
+	    expression="#[write(payload, 'text/plain')]" 
+	    is="#[MunitTools::equalTo('Hello World!')]" />
     </munit:validation>
 
 </munit:test>


### PR DESCRIPTION
Fix the assertion in the example to allow the test to complete without an error or assertion failure.
Added the write() to convert from binary to String before comparison, and added the missing exclamation mark to the expected value.