### PR TITLE
Fix error in pr 70

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :version-info: 3.7.0 and newer
 :keywords: munit, testing, unit testing
-:page-aliases: munit:index.adoc
+:page-aliases: general:getting-started:implement-and-test.adoc
 
 == Overview
 


### PR DESCRIPTION
@fermujica:
1. Link check performed, no errors.
2. Local build performed--weirdly, every link in the TOC worked except index.html for munit so I'm not sure if there's something wrong. The browser shows the file directory contents, and if I click on any file except index.html, the page displays. 