### PR TITLE
Fix StringContainsInOrder example

### DIFF
--- a/modules/ROOT/pages/string-matchers-reference.adoc
+++ b/modules/ROOT/pages/string-matchers-reference.adoc
@@ -97,7 +97,7 @@ Checks that the expression contains all of the specified substrings, regardless 
 ----
 <munit-tools:assert-that
 expression="#[payload]"
-is="#[MunitTools::stringContainsInOrder('an', 'example')]"/>
+is="#[MunitTools::stringContainsInOrder(['an', 'example'])]"/>
 ----
 
 == See Also


### PR DESCRIPTION
This was fixed in 2.1, but not in v2.2.