### PR TITLE
Fixed type in "mvn clean test -D "

### DIFF
--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -513,7 +513,7 @@ By using the property `munit.test`, you can instruct the MUnit Maven plugin to r
 
 [source,maven,linenums]
 ----
-mvn clean test -Dmunit.test=<regex-test-suite>
+mvn clean test -D munit.test=<regex-test-suite>
 ----
 
 This path is relative to `src/test/munit`.
@@ -524,7 +524,7 @@ For example:
 
 [source,console]
 ----
-mvn clean test -Dmunit.test=.*my-test.*
+mvn clean test -D munit.test=.*my-test.*
 ----
 
 You can leverage this feature by adding naming conventions to your MUnit Test suites.
@@ -535,14 +535,14 @@ In the same way that you instruct MUnit to run one test suite, you can also conf
 
 [source,console]
 ----
-mvn clean test -Dmunit.test=<regex-test-suite>#<regex-test-name>
+mvn clean test -D munit.test=<regex-test-suite>#<regex-test-name>
 ----
 
 It also accepts regular expressions. The expression is applied to the attribute `name` of the MUnit Test. For example:
 
 [source,console]
 ----
-mvn clean test -Dmunit.test=.*my-test.*#.*test-scenario-1.*
+mvn clean test -D munit.test=.*my-test.*#.*test-scenario-1.*
 ----
 
 The tests inside the MUnit Test Suite that don't match the regular expression are flagged as *ignored*.
@@ -570,7 +570,7 @@ You can run only the tests that you grouped under one specific tag:
 
 [source,console]
 ----
-mvn clean test -Dmunit.tags=<munit-tag>
+mvn clean test -D munit.tags=<munit-tag>
 ----
 
 You can also configure this from the `pom.xml` configuration:
@@ -690,7 +690,7 @@ You can specify the JVM (or the java executable) in which your applications bein
 .Specifying the JVM
 [source,console]
 ----
-mvn clean package -Dmunit.jvm=/path/to/jdk/bin/java
+mvn clean package -D munit.jvm=/path/to/jdk/bin/java
 ----
 
 You can also configure this from the `pom.xml` configuration:


### PR DESCRIPTION
There needs to be a space after the '-D' and the 'munit.test' in the maven commands