### PR TITLE
DBUtil - Update URL under Test_Database_Config

### DIFF
--- a/modules/ROOT/pages/db-util.adoc
+++ b/modules/ROOT/pages/db-util.adoc
@@ -169,7 +169,7 @@ Developer,10,DEV
 |===
 | _Name_ | `Test_Database_Config`
 | _Connection_ | `Generic connection`
-| _URL_ | `jdbc:h2:mem:DATABASE_NAME`
+| _URL_ | `jdbc:h2:tcp://localhost/mem:DATABASE_NAME`
 | _Driver class name_ | `org.h2.Driver`
 |===
 +


### PR DESCRIPTION
The URL under Test_Database_Config data table (line 172) is setted as "jdbc:h2:mem:DATABASE_NAME", instead of "jdbc:h2:tcp://localhost/mem:DATABASE_NAME" as the xml config under that table says.

This change is important, due to the fact that if the Test_Database_Config is configured with the URL "jdbc:h2:mem:DATABASE_NAME", leads to an extra instantiation of h2 in-memory database, that cause the MUnit Suite fail. 

There's a customer case, related to this: 00242418