### PR TITLE
Add caution note under "Setting Up Coverage"

### DIFF
--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -286,10 +286,8 @@ The following example overrides the console coverage report from its parent POM 
 ----
 
 == Setting Up Coverage
-[CAUTION]
---
-Setting up coverage feature is only available as part of the MUnit Maven Plugin. This feature does not work when running tests from inside Anypoint Studio.
---
+
+The following configurations only apply when you execute your MUnit tests using the Maven plugin. They do not apply when running tests from Studio. See xref:coverage-maven-concept.adoc[Using Coverage in Maven] for more information. 
 
 include::page$coverage-maven-concept.adoc[tags=coverage-report;!report-types,leveloffset=+1]
 

--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -286,6 +286,10 @@ The following example overrides the console coverage report from its parent POM 
 ----
 
 == Setting Up Coverage
+[CAUTION]
+--
+Setting up coverage feature is only available as part of the MUnit Maven Plugin. This feature does not work when running tests from inside Anypoint Studio.
+--
 
 include::page$coverage-maven-concept.adoc[tags=coverage-report;!report-types,leveloffset=+1]
 


### PR DESCRIPTION
Add caution note under "Setting Up Coverage", as this feature is available when running MUnit through Maven CLI only, and is not available for Anypoint Studio. Without a note like this, it may cause customers to try doing this in Anypoint Studio.