### PR TITLE
Matchers can't be used inside a normal transform

### DIFF
--- a/modules/ROOT/pages/assertion-expression-processor.adoc
+++ b/modules/ROOT/pages/assertion-expression-processor.adoc
@@ -66,5 +66,5 @@ If this assertion fails, the processor throws a `java.lang.AssertionError`.
 
 [WARNING]
 --
-Matchers from the `dw::test::Asserts` library are not compatible with the `MunitTools` matchers. You can't use `dw::test::Asserts` with the Assert-That processor, and you can't use `MunitTools` matchers with the Assert-Expression processor.
+Matchers from the `dw::test::Asserts` library are not compatible with the `MunitTools` matchers. You can't use `dw::test::Asserts` with the Assert-That processor, and you can't use `MunitTools` matchers with the Assert-Expression processor. You can't use `dw::test::Asserts` with a regular Transform processor.
 --


### PR DESCRIPTION
Add a clarification that this library can't be used with a normal transform in a flow https://docs.mulesoft.com/mule-runtime/4.2/transform-component-about