### PR TITLE
Add dependency munit-assert as a requirement to create custom assertion

### DIFF
--- a/modules/ROOT/pages/run-custom-event-processor.adoc
+++ b/modules/ROOT/pages/run-custom-event-processor.adoc
@@ -7,7 +7,19 @@ endif::[]
 
 The Run Custom event processor allows you to assert the Mule event content against a custom assertion.
 
-Although it's not necessary to add any extra dependencies to your `pom.xml` file, you must add your custom assertion class to the `mule-artifact.json` file as an exported resource.
+You have to add the next dependency to your `pom.xml` file:
+
+[source,xml,linenums]
+----
+<dependency>
+    <groupId>com.mulesoft.munit</groupId>
+    <artifactId>munit-assert</artifactId>
+    <version>${munit.version}</version>
+    <scope>test</scope>
+</dependency>
+----
+
+You must add your custom assertion class to the `mule-artifact.json` file as an exported resource.
 
 For example, you can define the following assertion in Java:
 

--- a/modules/ROOT/pages/run-custom-event-processor.adoc
+++ b/modules/ROOT/pages/run-custom-event-processor.adoc
@@ -19,7 +19,7 @@ To add the Run Custom processor to your project, add the following dependency to
 </dependency>
 ----
 
-You must add your custom assertion class to the `mule-artifact.json` file as an exported resource.
+You must also add your custom assertion class to the `mule-artifact.json` file as an exported resource.
 
 For example, you can define the following assertion in Java:
 

--- a/modules/ROOT/pages/run-custom-event-processor.adoc
+++ b/modules/ROOT/pages/run-custom-event-processor.adoc
@@ -7,7 +7,7 @@ endif::[]
 
 The Run Custom event processor allows you to assert the Mule event content against a custom assertion.
 
-You have to add the next dependency to your `pom.xml` file:
+To add the Run Custom processor to your project, add the following dependency to your `pom.xml` file:
 
 [source,xml,linenums]
 ----


### PR DESCRIPTION
In order to create a custom assertion is necessary to implement the interface MunitAssertion, that is not shipped in Studio, keeping in mind that the creation of a custom assertion is the only reason to need this dependency we think that is better to ask the user to add it manually when is needed.