### PR TITLE
Update enable-flow-sources-concept.adoc

### DIFF
--- a/modules/ROOT/pages/enable-flow-sources-concept.adoc
+++ b/modules/ROOT/pages/enable-flow-sources-concept.adoc
@@ -25,7 +25,7 @@ Assume that your application has a flow with an HTTP listener that returns a spe
 </flow>
 ----
 
-For MUnit to be able to invoke that listener you must enable the `http-transportFlow` in your `enable-flow-source` property within your MUnit test:
+For MUnit to be able to invoke that listener you must enable the `http-example-flow` in your `enable-flow-source` property within your MUnit test:
 
 [source,xml,linenums,subs="verbatim,attributes"]
 ----


### PR DESCRIPTION
The description erroneously referenced "http-tramsportFlow" instead of "http-example-flow"