### PR TITLE
SE-17499: Clarification for Maven plugin usage in Studio.

### DIFF
--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -6,7 +6,9 @@ endif::[]
 :keywords: munit, testing, unit testing
 :page-aliases: munit-maven-support.adoc, to-set-up-munit-maven-plugin.adoc, faq-working-with-parent-pom.adoc, to-inherit-parent-plugin.adoc, to-ignore-parent-plugin.adoc, to-override-parent-plugin.adoc, munit-maven-plugin-configuration.adoc,to-configure-munit-maven-plugin-maven.adoc
 
-MUnit provides a Maven plugin that allows you to run your MUnit tests as part of your continuous integration environment.
+MUnit provides a Maven plugin that enables you to run your MUnit tests as part of your continuous integration environment.
+
+The following configurations to the `pom.xml` or `settings.xml` files of your Maven installation only apply when running Munit through Maven.
 
 == Setting Up MUnit Maven Plugin
 
@@ -813,8 +815,9 @@ Default value: `${project.build.directory}/test-mule/munit`
 
 | `runtimeVersion`
 | String
-| Version of the Mule runtime
-By default, this value is taken from the `minMuleVersion` parameter in the `mule-artifact.json` file.
+| Version of the Mule runtime +
+When running your tests from Maven, this value is taken from the `minMuleVersion` parameter in the `mule-artifact.json` file. +
+To modify the Mule runtime version used to run your MUnit tests in Studio, see xref:runtime-patching.adoc#studio[Runtime Patching in Studio].
 
 
 | runtimeProduct

--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -8,7 +8,7 @@ endif::[]
 
 MUnit provides a Maven plugin that enables you to run your MUnit tests as part of your continuous integration environment.
 
-The following configurations to the `pom.xml` or `settings.xml` files of your Maven installation only apply when running Munit through Maven.
+The following configurations to the `pom.xml` or `settings.xml` files of your Maven installation apply only when running Munit through Maven.
 
 == Setting Up MUnit Maven Plugin
 
@@ -816,7 +816,7 @@ Default value: `${project.build.directory}/test-mule/munit`
 | `runtimeVersion`
 | String
 | Version of the Mule runtime +
-When running your tests from Maven, this value is taken from the `minMuleVersion` parameter in the `mule-artifact.json` file. +
+When you run your tests from Maven, this value is taken from the `minMuleVersion` parameter in the `mule-artifact.json` file. +
 To modify the Mule runtime version used to run your MUnit tests in Studio, see xref:runtime-patching.adoc#studio[Runtime Patching in Studio].
 
 

--- a/modules/ROOT/pages/runtime-patching.adoc
+++ b/modules/ROOT/pages/runtime-patching.adoc
@@ -3,8 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Patching in MUnit is different from patching in Mule runtime engine . MUnit runs using an embedded Mule container, which downloads all required dependencies to start Mule based on a given version. To use a patched Mule version (for example, `4.3.0-20200727`), you must point MUnit to run specifically against it. You can do this from either Maven or Anypoint Studio.
+Patching in MUnit is different from patching in Mule runtime engine. MUnit runs using an embedded Mule container, which downloads all required dependencies to start Mule based on a given version. To use a patched Mule version (for example, `4.3.0-20200727`), you must point MUnit to run specifically against it. You can do this from either Maven or Anypoint Studio.
 
+[[maven]]
 == Patching MUnit Using Maven
 
 By default, MUnit runs against the Mule version corresponding to the `minMuleVersion` defined in the `mule-artifact.json` file. You can override this version by using the `runtimeVersion` attribute of the `munit-maven-plugin` artifact configuration:
@@ -31,6 +32,7 @@ By default, MUnit runs against the Mule version corresponding to the `minMuleVer
 ----
 <1> Be sure to replace the placeholder version in this example with your version, as provided by MuleSoft.
 
+[[studio]]
 == Patching MUnit Using Studio
 
 By default, MUnit runs in Anypoint Studio with the Mule runtime engine version of the project’s server. You can override this version by specifying the patched Mule version in the MUnit run configuration menu:
@@ -42,7 +44,6 @@ By default, MUnit runs in Anypoint Studio with the Mule runtime engine version o
 image::runtime-patching-studio.png[]
 
 If you already set the `runtimeVersion` attribute in the POM file of your project, click *Load configuration from POM file* to automatically load this version into the *Mule Runtime Version* field.
-
 
 
 == See Also


### PR DESCRIPTION
Clarify that the Maven plugin config does not always apply to Studio run 
config.

Also added a link to runtime version config in Studio instructions.