### PR TITLE
typos + brackets

### DIFF
--- a/modules/ROOT/pages/coverage-maven-concept.adoc
+++ b/modules/ROOT/pages/coverage-maven-concept.adoc
@@ -71,7 +71,7 @@ The console report is printed to the console. It works with the summary report a
 * HTML report +
 The HTML report shows the same information as the console report, but formatted to fit any web browser. It is available in the `${application.path}/target/site/munit/coverage/` path.+
 * JSON report
-The JSON report shows the same information as the HTML report, but in a JSON format. It is availabie in the `${application.path}/target/site/munit/coverage/munit-coverage.json` path.+
+The JSON report shows the same information as the HTML report, but in a JSON format. It is available in the `${application.path}/target/site/munit/coverage/munit-coverage.json` path.+
 * The SONAR report shows the same information as the HTML report, in a SonarQube format. +
 
 To enable the report generation, add the following configuration:

--- a/modules/ROOT/pages/munit-maven-plugin.adoc
+++ b/modules/ROOT/pages/munit-maven-plugin.adoc
@@ -671,7 +671,7 @@ To set additional environment variables during the test run, you can specify the
 </plugins>
 ----
 
-As shown in the previous example, you can use environment variables to replace placeholders such as `${MY_ENV}`.
+As shown in the previous example, you can use environment variables to replace placeholders such as `$\{MY_ENV}`.
 
 === System Properties Variables
 
@@ -708,7 +708,7 @@ You can do so using the ­`-D` argument when running MUnit with Maven.  Variable
 
 When running several tests, the build output can get very complex to read. MUnit allows you to redirect the output of each test suite to a file. This way, only the test results will remain in the build output and to you can check the respective file to check the standard output of each test suite.
 
-These files are located in the `testOutputDirectory` folder following the naming convention: `munit.${suiteName}-output.txt`, where the `suiteName` represents the name of the XML file relative to the MUnit test folder.
+These files are located in the `testOutputDirectory` folder following the naming convention: `munit.$\{suiteName}-output.txt`, where the `suiteName` represents the name of the XML file relative to the MUnit test folder.
 
 The test's output that doesn't belong to a particular suite won't be printed to keep the build output clean, but it can be enabled by running maven in debug mode.
 

--- a/modules/ROOT/pages/test-recorder-examples.adoc
+++ b/modules/ROOT/pages/test-recorder-examples.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 The following example shows you how to import to Anypoint Studio an existing project from Anypoint Exchange and then record the flow processing to create a unit test for the flows.
 
-== Prerequesite
+== Prerequisite
 
 * Your Anypoint Platform credentials are configured in Studio. +
 See xref:studio::set-credentials-in-studio-to.adoc[Configuring Anypoint Platform Credentials] for more information.

--- a/modules/ROOT/pages/test-recorder.adoc
+++ b/modules/ROOT/pages/test-recorder.adoc
@@ -36,7 +36,7 @@ The test recorder is limited in the following ways when you create MUnit tests:
 * A recorded flow execution ends successfully, but the result does not reach its destination because the application is killed.
 * Your validations fail every time your test runs if you configure Spy or Assert processors to assert values for random data, time-dependent information (such as timestamps), or values resulting from parallel processes, because those values change in every execution.
 * Mocking values resulting from parallel processes causes a mixture of real and mocked data that compromises the execution of the processors that follow in your test.
-* Although the recorder supports data iteration in the flow, such as recursivity or loops, it does not support cases in which the structure of the data being tested changes inside the iteration.
+* Although the recorder supports data iteration in the flow, such as recursions or loops, it does not support cases in which the structure of the data being tested changes inside the iteration.
 * The recorder does not support mocking a message before or inside a Foreach processor.
 
 

--- a/modules/ROOT/pages/verify-event-processor.adoc
+++ b/modules/ROOT/pages/verify-event-processor.adoc
@@ -28,7 +28,7 @@ You can define verifications over any processor, even if you haven't created a m
 |Attribute Name |Description
 
 |`eventProcessor`
-|Describes which event processor you want to mock. The description takes the form `{name-space}:{event-processor-name}`. It supports regular expressions.
+|Describes which event processor you want to mock. The description takes the form `\{name-space}:\{event-processor-name}`. It supports regular expressions.
 
 |`times`
 |*(Default = 1.)* Defines the verification as successful if the event processor was called _N_ and only _N_ number of times.


### PR DESCRIPTION
- fix typos
- escape brackets to reduce warning messages during build times