### PR TITLE
Wrong apostrophes removed from MUnit project

### DIFF
--- a/modules/ROOT/pages/example-testing-apikit.adoc
+++ b/modules/ROOT/pages/example-testing-apikit.adoc
@@ -301,7 +301,7 @@ This example shows how to trigger hits to the endpoint exposed by APIkit, and wh
 
 Although this example is meant to showcase how to build a test suite from the ground, MUnit allows you to automatically create a test Suite based on your RAML definitions.
 
-Based on link:{attachmentsdir}/t-shirt.raml[complete t-shirt API definition], the MUnit's scaffolder automatically creates the following test Suite:
+Based on link:{attachmentsdir}/t-shirt.raml[complete t-shirt API definition], the MUnit scaffolder automatically creates the following test Suite:
 
 
 [.ex]
@@ -417,7 +417,7 @@ Additionally you can choose to disable the request/response file creation in cas
 
 The scaffolder doesn't make use of some new RAML 1.0 features yet. For example, if you define an element that has a certain type, the scaffolder won't generate a payload with that type's properties (like it does with JSON schema), it will generate an empty payload.
 
-// This scaffolder has limited support for RAML 1.0. A list of unsupported RAML 1.0 features by MUnit's scaffolder is presented below:
+// This scaffolder has limited support for RAML 1.0. A list of unsupported RAML 1.0 features by MUnit scaffolder is presented below:
 //
 //	* Security Schemes
 //	* Data Type operations: joins/unions/intersections

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -71,7 +71,7 @@ TIP: Currently the latest released versions of Mule MUnit Support are:  *3.6.5*,
 [[studio]]
 == MUnit and Anypoint Studio
 
-MUnit is fully integrated with Anypoint Studio, allowing you to create, design and run MUnit tests just like you would Mule applications. You can also use Anypoint Studio's xref:5@studio::studio-visual-debugger.adoc[Studio Visual Debugger] to debug your MUnit tests.
+MUnit is fully integrated with Anypoint Studio, allowing you to create, design and run MUnit tests just like you would Mule applications. You can also use Anypoint Studio xref:5@studio::studio-visual-debugger.adoc[Studio Visual Debugger] to debug your MUnit tests.
 
 For an overview of MUnit in Anypoint Studio, see xref:using-munit-in-anypoint-studio.adoc[Using MUnit in Anypoint Studio].
 
@@ -79,7 +79,7 @@ For an overview of MUnit in Anypoint Studio, see xref:using-munit-in-anypoint-st
 
 The pages listed below provide an overview of MUnit features including simple examples. Topics include the MUnit message processors, the DB and FTP servers provided by MUnit, Maven support and more. For a short step-by-step guide to creating a test, see the xref:munit-short-tutorial.adoc[MUnit Tutorial].
 
-TIP: The examples in these pages are XML-only; however, as stated <<studio,above>>, you can also use MUnit via Anypoint Studio's graphical interface. See xref:using-munit-in-anypoint-studio.adoc[Using MUnit in Anypoint Studio] for details.
+TIP: The examples in these pages are XML-only; however, as stated <<studio,above>>, you can also use MUnit via Anypoint Studio graphical interface. See xref:using-munit-in-anypoint-studio.adoc[Using MUnit in Anypoint Studio] for details.
 
 * xref:using-munit-in-anypoint-studio.adoc[Using MUnit in Anypoint Studio]
 * xref:munit-suite.adoc[MUnit Suite]

--- a/modules/ROOT/pages/testing-sap.adoc
+++ b/modules/ROOT/pages/testing-sap.adoc
@@ -31,7 +31,7 @@ This process is also described in the xref:3.8@mule-runtime::sap-connector-troub
 +
 . You may also need to make the `java.library.path` point to the folder where the native libraries are located. +
 The MUnit Studio plugin will try to find these native libraries and configure them automatically when you try to run your tests. In case they are not found, you need to add the following _vm argument_ in the run configuration:
-.. In Studio's top navigation bar, click *run*
+.. In Studio top navigation bar, click *run*
 .. Click *Run Configurations...*
 .. Select the *Arguments* tab
 .. In the *VM Arguments* dialog box, type the path to your libraries with the `java.library.path` argument. +

--- a/modules/ROOT/pages/using-munit-in-anypoint-studio.adoc
+++ b/modules/ROOT/pages/using-munit-in-anypoint-studio.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: mule, esb, tests, qa, quality assurance, verify, functional testing, unit testing, stress testing
 
-MUnit is fully integrated with Anypoint Studio. You can use Studio's graphical interface to:
+MUnit is fully integrated with Anypoint Studio. You can use Studio graphical interface to:
 
 * <<Creating a New MUnit Test in Studio,Create>> and design MUnit tests
 * <<Running Your Test,Run>> your tests
@@ -242,7 +242,7 @@ image::using-munit-in-anypoint-studio-2cd78.png[]
 
 == Debugging Tests
 
-You can debug MUnit tests just like Studio applications, using Studio's debugging perspective (for details on the debugging UI, see xref:6@studio::studio-visual-debugger.adoc[Studio Visual Debugger]).
+You can debug MUnit tests just like Studio applications, using Studio debugging perspective (for details on the debugging UI, see xref:6@studio::studio-visual-debugger.adoc[Studio Visual Debugger]).
 
 To access the debugging perspective, click *Mule Debug* on the top right of the Studio toolbar. This takes you away from the default Mule Design perspective to the debugging perspective, which displays debugging controls.
 


### PR DESCRIPTION
"MUnit's" replaced by "MUnit", and "Studio's" replaced by "Studio".
@fermujica, please, can you check this PR? Thanks!
