### PR TITLE
Update munit-matchers.adoc

### DIFF
--- a/modules/ROOT/pages/munit-matchers.adoc
+++ b/modules/ROOT/pages/munit-matchers.adoc
@@ -99,7 +99,7 @@ Example:
 +
 [source,DataWeave,options="nowrap"]
 ----
-#[MunitTools::allOf(MunitTools::notNullValue(),MunitTools::withMediaType('text/xml'),MunitTools::isEmptyString())]
+#[MunitTools::allOf([MunitTools::notNullValue(),MunitTools::withMediaType('text/xml'),MunitTools::isEmptyString()])]
 ----
 
 == Match Strings


### PR DESCRIPTION
wrapp parameters of MunitTools::allOf in an array so it has the correct syntax